### PR TITLE
Remove `validateStatus` method from config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,6 @@ async function axiosFetch (axios, transfomer, input, init = {}) {
     method: init.method || 'GET',
     data: init.body instanceof FormData ? init.body : String(init.body),
     headers: lowerCasedHeaders,
-    validateStatus: () => true,
     // Force the response to an arraybuffer type. Without this, the Response
     // object will try to guess the content type and add headers that weren't in
     // the response.
@@ -31,7 +30,12 @@ async function axiosFetch (axios, transfomer, input, init = {}) {
     responseType: 'arraybuffer'
   }, input, init);
 
-  const result = await axios.request(config);
+  let result;
+  try {
+    result = await axios.request(config);
+  } catch (err) {
+    result = err.response;
+  }
 
   const headers = new Headers(result.headers);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -214,3 +214,19 @@ test('allows transforming request options', async function (test) {
   sinon.assert.calledOn(requestSpy, client);
   sinon.assert.calledWithExactly(requestSpy, newConfig);
 });
+
+test('works with axios interceptors', async function (test) {
+  const instance = axios.create();
+  instance.interceptors.response.use(
+    function (successRes) {
+      return successRes;
+    },
+    function (error) {
+      error.config.url = `${TEST_URL_ROOT}/success/text`;
+      return instance(error.config);
+    }
+  );
+  const axiosFetch = buildAxiosFetch(instance);
+  const axiosResponse = await axiosFetch(`${TEST_URL_ROOT}/failure`);
+  test.truthy(axiosResponse.status === 200);
+});


### PR DESCRIPTION
Fixes an issue where axios interceptors are not used properly because `validateStatus` always returns `true`

Fixes #43 