### PR TITLE
Check for `undefined` body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ async function axiosFetch (axios, transfomer, input, init = {}) {
   const config = transfomer({
     url: input,
     method: init.method || 'GET',
-    data: init.body instanceof FormData ? init.body : String(init.body),
+    data: typeof init.body === 'undefined' || init.body instanceof FormData ? init.body : String(init.body),
     headers: lowerCasedHeaders,
     validateStatus: () => true,
     // Force the response to an arraybuffer type. Without this, the Response

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -142,6 +142,19 @@ test('handles json body init options', async function (test) {
   test.deepEqual(axiosBody.headers['content-type'], expectedBody.headers['content-type']);
 });
 
+test('handles undefined body in init options', async function (test) {
+  const init = {
+    method: 'POST',
+    body: undefined
+  };
+  const { expectedResponse, axiosResponse } = await dualFetch(`${TEST_URL_ROOT}/body`, init);
+
+  const expectedBody = await expectedResponse.json();
+  const axiosBody = await axiosResponse.json();
+
+  test.deepEqual(axiosBody.body, expectedBody.body);
+});
+
 test('returns the expected response on a multipart request', async function (test) {
   const data = new FormData();
   data.append('key', 'value');


### PR DESCRIPTION
Checks if `init.body` is defined before converting it to a string in `axiosFetch` method.

Fixes #63 