### PR TITLE
Fix AxiosFetch type to return Promise

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export interface FetchInit extends Record<string, any> {
 
 export type AxiosTransformer = (config: AxiosRequestConfig, input: string | undefined, init: FetchInit) => AxiosRequestConfig;
 
-export type AxiosFetch = (input?: string, init?: FetchInit) => Response;
+export type AxiosFetch = (input?: string, init?: FetchInit) => Promise<Response>;
 
 /**
  * A Fetch WebAPI implementation based on the Axios client
@@ -19,7 +19,7 @@ export type AxiosFetch = (input?: string, init?: FetchInit) => Response;
 async function axiosFetch (
   axios: AxiosInstance,
   // Convert the `fetch` style arguments into a Axios style config
-  transformer: AxiosTransformer,
+  transformer?: AxiosTransformer,
   input?: string,
   init: FetchInit = {}
 ) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "strict": true,
     "alwaysStrict": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
Fixes https://github.com/lifeomic/axios-fetch/issues/71.

The `AxiosFetch` type was incorrect because it declares to return `Response` where it actually returns `Promise<Response>`.

This PR also enables the `strict` option to ensure the implementation and the type declaration better match with each other.