### PR TITLE
fix: proper fetch-spec related input handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "test": "nyc ava",
-    "lint": "eslint . --ext .js,.ts -f codeframe && tsc --noEmit",
+    "lint": "eslint . --ext .ts -f codeframe && tsc --noEmit",
     "pretest": "yarn lint",
     "coverage": "nyc report --reporter=text-lcov > ./.nyc_output/lcov.info",
     "prepublishOnly": "yarn tsc"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,46 +1,43 @@
-import { Response, Headers as FetchHeaders } from 'node-fetch';
-import FormData from 'form-data';
+import { Response, Request, Headers as FetchHeaders, RequestInfo, RequestInit } from 'node-fetch';
 import { AxiosInstance, AxiosRequestConfig } from './types';
+import FormData from 'form-data';
 
-export interface FetchInit extends Record<string, any> {
-  headers?: Record<string, string>;
-  method?: AxiosRequestConfig['method'];
-  body?: FormData | any;
-  extra?: any;
-}
+export type AxiosTransformer = (config: AxiosRequestConfig, input: RequestInfo, init?: RequestInit) => AxiosRequestConfig;
 
-export type AxiosTransformer = (config: AxiosRequestConfig, input: string | undefined, init: FetchInit) => AxiosRequestConfig;
-
-export type AxiosFetch = (input?: string, init?: FetchInit) => Promise<Response>;
+export type AxiosFetch = (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 
 /**
  * A Fetch WebAPI implementation based on the Axios client
+ *
+ * @param axios
+ * @param transformer Convert the `fetch` style arguments into a Axios style config
+ * @param input
+ * @param init
  */
 async function axiosFetch (
   axios: AxiosInstance,
-  // Convert the `fetch` style arguments into a Axios style config
-  transformer?: AxiosTransformer,
-  input?: string,
-  init: FetchInit = {}
+  transformer: AxiosTransformer | undefined,
+  input: RequestInfo,
+  init?: RequestInit
 ) {
-  const rawHeaders: Record<string, string> = init.headers || {};
-  const lowerCasedHeaders = Object.keys(rawHeaders)
-    .reduce<Record<string, string>>(
-      (acc, key) => {
-        acc[key.toLowerCase()] = rawHeaders[key];
-        return acc;
-      },
-      {}
-    );
+  // Request class handles for us all the input normalisation
+  const request = new Request(input, init);
+  const lowerCasedHeaders: Record<string, string> = {};
+
+  for (const entry of request.headers.entries()) {
+    lowerCasedHeaders[entry[0].toLowerCase()] = entry[1];
+  }
 
   if (!('content-type' in lowerCasedHeaders)) {
     lowerCasedHeaders['content-type'] = 'text/plain;charset=UTF-8';
   }
 
+  const data = init?.body instanceof FormData ? init?.body : await request.arrayBuffer();
+
   const rawConfig: AxiosRequestConfig = {
-    url: input,
-    method: init.method || 'GET',
-    data: typeof init.body === 'undefined' || init.body instanceof FormData ? init.body : String(init.body),
+    url: request.url,
+    method: (request.method || 'GET') as AxiosRequestConfig['method'],
+    data: data,
     headers: lowerCasedHeaders,
     // Force the response to an arraybuffer type. Without this, the Response
     // object will try to guess the content type and add headers that weren't in


### PR DESCRIPTION
Closes #83 

This PR improves spec compliance of this library with accepting `Request` instance as input and several other small improvements (see comments).

Also, I am not sure how `form-data` package works with axios as axios should not accept anything else than DOM instance of `form-data` as you can see [here](https://github.com/axios/axios/blob/master/lib/utils.js#L57), but it indeed works which leaves me bit buffled. But I would advise against using `form-data as it is non-compliant with the spec.

Btw. also I would recommend separating the compiled JS files into build directory as for example if you build the project and then run tests it uses the builder sources and not the TypeScript one.