### PR TITLE
Add an explicit `: any` annotation to `catch` clause for TypeScript 4.4

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ async function axiosFetch (
   let result;
   try {
     result = await axios.request(config);
-  } catch (err) {
+  } catch (err: any) {
     if (err.response) {
       result = err.response;
     } else {


### PR DESCRIPTION
Since TypeScript 4.4, the default argument of `catch` clause was changed to `unknown`, which caused a type error.
https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables

To avoid the error, I changed the `catch` clause argument to specify `: any` annotation explicitly.