### PR TITLE
Fix header class detection

### DIFF
--- a/src/typeUtils.ts
+++ b/src/typeUtils.ts
@@ -15,7 +15,7 @@ export function createFetchHeaders (axiosHeaders: Record<string, string> = {}): 
   return headers;
 }
 
-const isHeaders = (headers: HeadersLike): headers is Headers => headers.constructor.name === 'Headers';
+const isHeaders = (headers: HeadersLike): headers is Headers => headers.constructor?.name === 'Headers';
 
 export function createAxiosHeaders (headers: HeadersLike = {}): Record<string, string> {
   const rawHeaders: Record<string, string> = {};

--- a/test/typeUtils.test.ts
+++ b/test/typeUtils.test.ts
@@ -1,10 +1,10 @@
 import test from 'ava';
+import { Headers as NodeHeaders, Request } from 'node-fetch';
 import {
   createAxiosHeaders,
   createFetchHeaders,
   getUrl
 } from '../src/typeUtils';
-import { Request, Headers as NodeHeaders } from 'node-fetch';
 
 const headersObject = {
   key1: 'value1',
@@ -38,6 +38,10 @@ test('createFetchHeaders will create a proper Headers object', (t) => {
 test('createAxiosHeaders will return an empty object on undefined', (t) => {
   t.deepEqual(createAxiosHeaders(), {});
   t.deepEqual(createAxiosHeaders({ 'undefined': undefined }), {});
+});
+
+test('createAxiosHeaders will work with Headers object without a prototype', (t) => {
+  t.deepEqual(createAxiosHeaders(Object.create(null)), {});
 });
 
 test('createAxiosHeaders will format fetch style Headers object for Axios', (t) => {


### PR DESCRIPTION
When you create a new object by using `Object.create(null)` then this new instance doesn't inherit from anything. It means `Object.create(null).constructor === undefined` (https://stackoverflow.com/a/15518712/14750967). And that is the error we are encountering and this PR is fixing.

That is the way how `apollo/client@3.7` is preparing headers which are then passed to `axios-fetch` https://github.com/apollographql/apollo-client/blob/9134aaf3b6fc398b2d82439b5b63848b533ae4c9/src/link/http/selectHttpOptionsAndBody.ts#L203.

This is a regression caused by the following cleanup commit https://github.com/lifeomic/axios-fetch/commit/33d696262a27b4a6a5e88c3d1fe4558c5a864776.

Added test to reproduce this problem.