### PR TITLE
fix: set body to null if given empty buffer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import {
   createAxiosHeaders,
   createFetchHeaders,
-  getUrl
+  getUrl,
+  isBuffer
 } from './typeUtils';
 import { AxiosInstance, AxiosRequestConfig } from './axios-types';
 
@@ -54,7 +55,10 @@ const axiosFetch = <Init extends RequestInit = RequestInit>(
       }
     }
 
-    return new Response(result.data, {
+    const data = result.data as unknown;
+    const body = isBuffer(data) && !data.length ? null : result.data;
+
+    return new Response(body, {
       status: result.status,
       statusText: result.statusText,
       headers: createFetchHeaders(result.headers)

--- a/src/typeUtils.ts
+++ b/src/typeUtils.ts
@@ -17,6 +17,10 @@ export function createFetchHeaders (axiosHeaders: Record<string, string> = {}): 
 
 const isHeaders = (headers: HeadersLike): headers is Headers => headers.constructor?.name === 'Headers';
 
+export function isBuffer (input: unknown): input is Buffer {
+  return Buffer.isBuffer(input);
+}
+
 export function createAxiosHeaders (headers: HeadersLike = {}): Record<string, string> {
   const rawHeaders: Record<string, string> = {};
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -50,6 +50,8 @@ test.before(() => {
         body
       };
     })
+    .get('/no-content')
+    .reply(204)
     .get('/failure')
     .reply(501)
     .get('/failureBody')
@@ -90,6 +92,15 @@ test('returns the expected response on a text body', async (test) => {
   const axiosBody = await axiosResponse.text();
   test.deepEqual(axiosBody, expectedBody);
   test.deepEqual(axiosResponse.headers, expectedResponse.headers as any);
+});
+
+test('returns the expected response on HTTP status code no-content', async (test) => {
+  const { expectedResponse, axiosResponse } = await dualFetch(`${TEST_URL_ROOT}/no-content`);
+
+  test.truthy(axiosResponse.ok === expectedResponse.ok);
+  test.truthy(axiosResponse.status === expectedResponse.status);
+
+  test.truthy(axiosResponse.body === null);
 });
 
 test('respects the headers init option', async (test) => {


### PR DESCRIPTION
Here's a PR that verifies the body is null. If the result data is an empty buffer, pass null as body instead.
Ideally I would like to verify the node16-18 behaviour but the tests here hard-code the `fetch` and `Response` implementation to utilise `node-fetch` which behaves differently to node18s native `fetch` that utilises `undici`.